### PR TITLE
Add support for re-publishing cumulative playlists to Spotify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python: "3.5"
 install: pip install requests
-script: python3 script.py --push
+script: python3 script.py update --push

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,36 @@
+# Developing and Contributing
+
+## Getting API Access
+
+See the Spotify [Web API
+Tutorial](https://developer.spotify.com/documentation/web-api/quick-start/).
+
+Put the _client id_ and _client secret_ in the environment variables
+`SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` respectively.
+
+## Setting up the Export Feature
+
+In order to use the export feature, where the it re-publishes the
+cumulative playlists to spotify, the script needs to have access to a
+user. For that to work, the url http://localhost:8000 needs to be
+added to the _Redirect URIs_ field of the app settings. When that's
+done, getting a token should be as simple as running the script like
+this:
+
+```
+$ python script.py login
+Opening the following URL in a browser (at least trying to):
+https://accounts.spotify.com/authorize?client_id=...&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8000&scope=playlist-modify-public
+127.0.0.1 - - [05/Jan/2021 20:54:52] "GET /?code=some-secret-code HTTP/1.1" 200 -
+Refresh token, store this somewhere safe and use for the export feature:
+some-secret-code
+```
+
+Put the code in the environment variable `SPOTIFY_USER_TOKEN` to give
+the script access to your playlists.
+
+A few notes:
+- The script stores the re-exported playlist id in `playlists/export`.
+- A playlist is tied to a specific user. If a playlist exists but you
+  don't have access to it, you have to remove the corresponding entry
+  in `playlists/export` and run the script again.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Since Spotify won't take snapshots of our favorite playlists, let's do it oursel
 1. To determine which songs were added or removed from a playlist, click "githistory"
 1. To add a playlist to the archive, simply `touch playlists/plain/<playlist_id>` and make a pull request
 
+For info on development, see [Hacking](./HACKING.md).
+
 ## How it works
 
 This repository contains a script for scraping Spotify playlists and publishing


### PR DESCRIPTION
Got the idea from #23 and this is a first attempt at adding such a feature. The changes were a bit more extensive than I'd hoped since the API requires user access to create and modify playlists. I'd actually suggest creating a new Spotify user for hosting these playlists!

So what does it do?

If the script is run with `--export` it publishes all _current_ songs to a public playlist with name _\<original name> (archive)_ to the logged in user's account. if the playlist doesn't exist, it creates it and stores the id in `playlists/export/<playlist-id>` (i.e. a file with a single line containing the exported playlist id)

Notes:
- To log in, use the newly created `login` command, i.e. `python script.py login`.
- Currently, the exported playlist is its own cumulative playlist and does not interact with the one in `playlists/cumulative`.
- In any way switching the user account associated with exported playlists requires `playlists/export` to be cleared since you can't change another user's playlist (unless it's collaborative, which wouldn't really work out).
- Tested on python 3.8, let me know if it doesn't work on 3.5 (or update the version on Travis, 3.5 is quite old)

Please let me know if you need any help understanding it or if you want me to change things. I was thinking about adding more error checking in the requests and making the code more consistent style-wise but it felt better to just put it out there first.