### PR TITLE
Use relative URLs in markdown files.

### DIFF
--- a/script.py
+++ b/script.py
@@ -415,29 +415,29 @@ class Formatter:
 
 class URL:
 
-    BASE = (
-        "https://github.com/mackorone/spotify-playlist-archive/"
-        "blob/master/playlists/"
+    BASE = "/playlists"
+    HISTORY_BASE = (
+        "https://github.githistory.xyz/mackorone/spotify-playlist-archive/"
+        "blob/master/playlists"
     )
 
     @classmethod
     def plain_history(cls, playlist_id):
-        plain = cls.plain(playlist_id)
-        return plain.replace("github.com", "github.githistory.xyz")
+        return cls.HISTORY_BASE + "/plain/{}".format(playlist_id)
 
     @classmethod
     def plain(cls, playlist_id):
-        return cls.BASE + "plain/{}".format(playlist_id)
+        return cls.BASE + "/plain/{}".format(playlist_id)
 
     @classmethod
     def pretty(cls, playlist_name):
         sanitized = playlist_name.replace(" ", "%20")
-        return cls.BASE + "pretty/{}.md".format(sanitized)
+        return cls.BASE + "/pretty/{}.md".format(sanitized)
 
     @classmethod
     def cumulative(cls, playlist_name):
         sanitized = playlist_name.replace(" ", "%20")
-        return cls.BASE + "cumulative/{}.md".format(sanitized)
+        return cls.BASE + "/cumulative/{}.md".format(sanitized)
 
 
 def update_files(now):


### PR DESCRIPTION
Github is smart enough to do what you want! This works seamlessly with any branch and commit, which means that it's now possible to navigate the tree at any point.

Here's an example: https://github.com/Prillan/spotify-playlist-archive/tree/da7cc3ea0e79a4a411ef9e64059c46104777b133

The links in the readme leads to the files at that commit!